### PR TITLE
feat: add macOS one-shot setup with Makefile and Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,21 @@
+# Shell
+brew "zsh-autosuggestions"
+brew "zsh-syntax-highlighting"
+brew "zsh-completions"
+brew "zsh-git-prompt"
+brew "peco"
+
+# Editor / Multiplexer
+brew "vim"
+brew "tmux"
+
+# Git
+brew "git"
+brew "gh"
+
+# Search
+brew "fzf"
+brew "ripgrep"
+
+# Node.js version manager
+brew "anyenv"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+DOTFILES_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
+.PHONY: all install brew symlinks vim
+
+all: install
+
+install: brew symlinks vim
+	@echo "Setup complete. Restart your shell or run: source ~/.zshrc"
+
+brew:
+	@which brew > /dev/null 2>&1 || \
+		/bin/bash -c "$$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+	brew bundle --file=$(DOTFILES_DIR)/Brewfile
+
+symlinks:
+	ln -sf $(DOTFILES_DIR)/zsh/.zshrc     $(HOME)/.zshrc
+	ln -sf $(DOTFILES_DIR)/vim/.vimrc     $(HOME)/.vimrc
+	ln -sf $(DOTFILES_DIR)/tmux/.tmux.conf $(HOME)/.tmux.conf
+
+vim:
+	vim +PlugInstall +qall

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -3,8 +3,9 @@
 #################################
 
 # init
-source /usr/local/share/zsh-autosuggestions/zsh-autosuggestions.zsh
-source /usr/local/opt/zsh-git-prompt/zshrc.sh
+source $(brew --prefix)/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+source $(brew --prefix)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+source $(brew --prefix)/opt/zsh-git-prompt/zshrc.sh
 zstyle ":completion:*:commands" rehash 1
 autoload -Uz colors && colors
 autoload -Uz chpwd_recent_dirs cdr add-zsh-hook


### PR DESCRIPTION
## Summary

- `Makefile` を追加 — `make install` 一発で Homebrew インストール・パッケージ導入・シンボリックリンク作成・vim プラグインインストールまで完結
- `Brewfile` を追加 — 必要な brew パッケージを宣言的に管理
- `zsh/.zshrc` を修正 — `/usr/local` ハードコードパスを `$(brew --prefix)` に変更し Intel/Apple Silicon 両対応、`zsh-syntax-highlighting` を追加

## 使い方

```zsh
git clone https://github.com/kuni0128/dotfiles.git ~/dotfiles
cd ~/dotfiles
make install
```

## Test plan

- [ ] Apple Silicon Mac で `make install` を実行し、エラーなく完了することを確認
- [ ] シンボリックリンクが `~/.zshrc`, `~/.vimrc`, `~/.tmux.conf` に作成されることを確認
- [ ] `source ~/.zshrc` でエラーが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)