### PR TITLE
feat: support cross-platform setup for macOS and Ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,3 @@
-DOTFILES_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
-
-.PHONY: all install brew symlinks vim
-
-all: install
-
-install: brew symlinks vim
-	@echo "Setup complete. Restart your shell or run: source ~/.zshrc"
-
-brew:
-	@which brew > /dev/null 2>&1 || \
-		/bin/bash -c "$$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-	brew bundle --file=$(DOTFILES_DIR)/Brewfile
-
-symlinks:
-	ln -sf $(DOTFILES_DIR)/zsh/.zshrc     $(HOME)/.zshrc
-	ln -sf $(DOTFILES_DIR)/vim/.vimrc     $(HOME)/.vimrc
-	ln -sf $(DOTFILES_DIR)/tmux/.tmux.conf $(HOME)/.tmux.conf
-
-vim:
-	vim +PlugInstall +qall
+.PHONY: install
+install:
+	bash install.sh

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -e
+
+DOTFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
+OS="$(uname -s)"
+
+install_macos() {
+  which brew > /dev/null 2>&1 || \
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  brew bundle --file="$DOTFILES_DIR/Brewfile"
+}
+
+install_ubuntu() {
+  sudo apt update
+  sudo apt install -y \
+    zsh \
+    zsh-autosuggestions \
+    zsh-syntax-highlighting \
+    vim \
+    tmux \
+    git \
+    fzf \
+    ripgrep \
+    peco
+
+  if ! which gh > /dev/null 2>&1; then
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] \
+      https://cli.github.com/packages stable main" \
+      | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+    sudo apt update && sudo apt install -y gh
+  fi
+
+  if [ ! -d "$HOME/.anyenv" ]; then
+    git clone https://github.com/anyenv/anyenv "$HOME/.anyenv"
+    "$HOME/.anyenv/bin/anyenv" install --init
+  fi
+}
+
+setup_symlinks() {
+  ln -sf "$DOTFILES_DIR/zsh/.zshrc"       "$HOME/.zshrc"
+  ln -sf "$DOTFILES_DIR/vim/.vimrc"       "$HOME/.vimrc"
+  ln -sf "$DOTFILES_DIR/tmux/.tmux.conf"  "$HOME/.tmux.conf"
+}
+
+case "$OS" in
+  Darwin)
+    echo "[macOS] Installing packages..."
+    install_macos
+    ;;
+  Linux)
+    echo "[Ubuntu] Installing packages..."
+    install_ubuntu
+    ;;
+  *)
+    echo "Unsupported OS: $OS" && exit 1
+    ;;
+esac
+
+setup_symlinks
+vim +PlugInstall +qall
+echo "Done. Run: source ~/.zshrc"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -3,9 +3,18 @@
 #################################
 
 # init
-source $(brew --prefix)/share/zsh-autosuggestions/zsh-autosuggestions.zsh
-source $(brew --prefix)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
-source $(brew --prefix)/opt/zsh-git-prompt/zshrc.sh
+case "$(uname -s)" in
+  Darwin)
+    source $(brew --prefix)/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+    source $(brew --prefix)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+    source $(brew --prefix)/opt/zsh-git-prompt/zshrc.sh
+    ;;
+  Linux)
+    source /usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+    source /usr/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+    [[ -f /usr/share/zsh-git-prompt/zshrc.sh ]] && source /usr/share/zsh-git-prompt/zshrc.sh
+    ;;
+esac
 zstyle ":completion:*:commands" rehash 1
 autoload -Uz colors && colors
 autoload -Uz chpwd_recent_dirs cdr add-zsh-hook
@@ -24,20 +33,11 @@ alias gc="git checkout"
 alias distinct='awk '\''!a[$0]++'\'
 
 # env
-FPATH=$(brew --prefix)/share/zsh-completions:$FPATH
+[[ "$(uname -s)" == "Darwin" ]] && FPATH=$(brew --prefix)/share/zsh-completions:$FPATH
 HISTFILE=~/.zsh_history
 HISTSIZE=100000
 SAVEHIST=100000
 typeset -U path PATH
-path=(
-  /usr/local/bin
-  /System/Cryptexes/App/usr/bin
-  /usr/bin
-  /bin
-  /usr/sbin
-  /sbin
-  /Library/Apple/usr/bin
-)
 PROMPT="%F{green}%n%f %F{cyan}($(git_super_status))%f:%F{185}%~%f"$'\n'"%# "
 
 # functions


### PR DESCRIPTION
## Summary

- `install.sh` を追加 — OS判定 (Darwin/Linux) でパッケージインストールを分岐。macOS は Homebrew+Brewfile、Ubuntu は apt+gh-cli+anyenv を使用
- `Makefile` を簡略化 — `bash install.sh` を呼ぶだけのラッパーに変更
- `zsh/.zshrc` を修正 — `uname -s` による case 文でプラグインの source パスを OS ごとに切り替え。FPATH/zsh-completions の設定も macOS のみに限定

## 使い方 (macOS / Ubuntu 共通)

```zsh
git clone https://github.com/kuni0128/dotfiles.git ~/dotfiles
cd ~/dotfiles
make install   # または bash install.sh
```

## Test plan

- [ ] macOS で `make install` を実行しエラーなく完了することを確認
- [ ] Ubuntu で `make install` を実行しエラーなく完了することを確認
- [ ] 両 OS で `source ~/.zshrc` がエラーなく通ることを確認
- [ ] シンボリックリンクが `~/.zshrc`, `~/.vimrc`, `~/.tmux.conf` に作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)