### PR TITLE
fix: install zsh-git-prompt on Ubuntu and guard PROMPT

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,6 +40,11 @@ install_ubuntu() {
     git clone https://github.com/anyenv/anyenv "$HOME/.anyenv"
     "$HOME/.anyenv/bin/anyenv" install --init
   fi
+
+  # zsh-git-prompt is not available via apt
+  if [ ! -d "$HOME/.zsh-git-prompt" ]; then
+    git clone https://github.com/olivierverdier/zsh-git-prompt "$HOME/.zsh-git-prompt"
+  fi
 }
 
 setup_symlinks() {

--- a/nvim/lazy-lock.json
+++ b/nvim/lazy-lock.json
@@ -1,0 +1,13 @@
+{
+  "Comment.nvim": { "branch": "master", "commit": "e30b7f2008e52442154b66f7c519bfd2f1e32acb" },
+  "gitsigns.nvim": { "branch": "main", "commit": "dd3f588bacbeb041be6facf1742e42097f62165d" },
+  "gruvbox.nvim": { "branch": "main", "commit": "154eb5ff5b96d0641307113fa385eaf0d36d9796" },
+  "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },
+  "lualine.nvim": { "branch": "master", "commit": "131a558e13f9f28b15cd235557150ccb23f89286" },
+  "neo-tree.nvim": { "branch": "v3.x", "commit": "84c75e7a7e443586f60508d12fc50f90d9aee14e" },
+  "nui.nvim": { "branch": "main", "commit": "de740991c12411b663994b2860f1a4fd0937c130" },
+  "nvim-surround": { "branch": "main", "commit": "2e93e154de9ff326def6480a4358bfc149d5da2c" },
+  "nvim-web-devicons": { "branch": "master", "commit": "2795c26c916bb3c57dde308b82be51971fa92747" },
+  "plenary.nvim": { "branch": "master", "commit": "74b06c6c75e4eeb3108ec01852001636d85a932b" },
+  "telescope.nvim": { "branch": "master", "commit": "f04ab730b8f9c6bf3f54a206d0dcddfd70c52d59" }
+}

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -12,7 +12,7 @@ case "$(uname -s)" in
   Linux)
     source /usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh
     source /usr/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
-    [[ -f /usr/share/zsh-git-prompt/zshrc.sh ]] && source /usr/share/zsh-git-prompt/zshrc.sh
+    [[ -f $HOME/.zsh-git-prompt/zshrc.sh ]] && source $HOME/.zsh-git-prompt/zshrc.sh
     ;;
 esac
 zstyle ":completion:*:commands" rehash 1
@@ -40,7 +40,11 @@ HISTFILE=~/.zsh_history
 HISTSIZE=100000
 SAVEHIST=100000
 typeset -U path PATH
-PROMPT="%F{green}%n%f %F{cyan}($(git_super_status))%f:%F{185}%~%f"$'\n'"%# "
+if typeset -f git_super_status > /dev/null; then
+  PROMPT="%F{green}%n%f %F{cyan}($(git_super_status))%f:%F{185}%~%f"$'\n'"%# "
+else
+  PROMPT="%F{green}%n%f:%F{185}%~%f"$'\n'"%# "
+fi
 
 # functions
 add_newline() {


### PR DESCRIPTION
## Summary

Ubuntu で `source ~/.zshrc` した際に `git_super_status: command not found` エラーが出る問題を修正。

### 原因
- `zsh-git-prompt` は apt パッケージとして提供されていない
- `.zshrc` の PROMPT が `git_super_status` を無条件に呼び出している

### 変更内容
- `install.sh`: Ubuntu で `git clone` 経由で `~/.zsh-git-prompt` にインストール
- `zsh/.zshrc`: Linux 分岐の source 先を `~/.zsh-git-prompt/zshrc.sh` に変更
- `zsh/.zshrc`: PROMPT を `typeset -f git_super_status` でガードし、未インストール時はシンプルなプロンプトにフォールバック

## おまけ

`nvim/lazy-lock.json` も一緒にコミットされています。これは lazy.nvim が生成するプラグインのバージョン固定ファイルで、`package-lock.json` 相当のもの。再現性のために git 管理するのが一般的なので含めましたが、不要なら `.gitignore` するか別途削除してください。

## Test plan

- [ ] Ubuntu で `bash install.sh` 再実行 → `~/.zsh-git-prompt` が作成される
- [ ] 新しい zsh セッションで `git_super_status` エラーが出ないこと
- [ ] git リポジトリ内でプロンプトに git status (ブランチ名等) が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)