### PR TITLE
feat: add google-cloud-sdk cask to Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -21,3 +21,6 @@ brew "anyenv"
 
 # Secrets
 brew "sops"
+
+# Google Cloud SDK
+cask "google-cloud-sdk"


### PR DESCRIPTION
## Summary
- Brewfile に `google-cloud-sdk` を cask として追加し、`gcloud` CLI を `brew bundle` で導入できるようにする

## Test plan
- [ ] `brew bundle --file=Brewfile` が成功する
- [ ] インストール後 `gcloud --version` が動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)