### PR TITLE
feat: add direnv for per-directory env var loading

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -22,5 +22,8 @@ brew "anyenv"
 # Secrets
 brew "sops"
 
+# Env
+brew "direnv"
+
 # Google Cloud SDK
 cask "google-cloud-sdk"

--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,8 @@ install_ubuntu() {
     git \
     fzf \
     ripgrep \
-    peco
+    peco \
+    direnv
 
   if ! which gh > /dev/null 2>&1; then
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -40,6 +40,7 @@ HISTFILE=~/.zsh_history
 HISTSIZE=100000
 SAVEHIST=100000
 typeset -U path PATH
+command -v direnv > /dev/null && eval "$(direnv hook zsh)"
 if typeset -f git_super_status > /dev/null; then
   PROMPT="%F{green}%n%f %F{cyan}($(git_super_status))%f:%F{185}%~%f"$'\n'"%# "
 else


### PR DESCRIPTION
## Summary
- Brewfile / apt インストールリストに `direnv` を追加 (macOS / Ubuntu 両対応)
- `.zshrc` に direnv hook を追加 (`command -v direnv` で direnv 未導入環境でもエラーにならないようガード)

## Motivation
`BUNDLE_RUBYGEMS__PKG__GITHUB__COM` のようなプロジェクト固有の環境変数を、ディレクトリ単位で自動 load できるようにする。
運用パターン (例):
```bash
# プロジェクトの .envrc (コミットOK)
dotenv

# プロジェクトの .env (gitignore)
BUNDLE_RUBYGEMS__PKG__GITHUB__COM=ghp_xxx
```

## Test plan
- [ ] macOS: `brew bundle` 成功 / `direnv --version` 動作
- [ ] Ubuntu: `make install` がデグレなく完走 / `direnv` が apt から入る
- [ ] 新しいシェルで `direnv` hook が有効になり、`.envrc` 配置時に allow 促されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)